### PR TITLE
Update live-script-generation.md

### DIFF
--- a/live-script-generation.md
+++ b/live-script-generation.md
@@ -40,6 +40,12 @@ R2025a or newer
   %[text] - Third item\
   ```
 
+### Output Preferences
+- Prefer one output per code block
+- Avoid multiple outputs per code block, except during loops or repeated function calls
+- To display text values, leave off the semicolon
+- Do not use `fprintf` or similar commands to display text
+
 ## Script Template Structure
 
 Every Live Script should follow this structure:


### PR DESCRIPTION
This pull request adds new guidelines to the documentation for generating MATLAB Live Scripts, specifically focusing on output formatting preferences.

Output formatting guidelines:

* Added a new "Output Preferences" section to `live-script-generation.md` with recommendations to prefer one output per code block, avoid multiple outputs except in loops, display text by omitting the semicolon, and not use `fprintf` or similar commands for text display.